### PR TITLE
Fix NumElements() off-by-one

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -129,7 +129,7 @@ func (f *Fuzzer) genElementCount() int {
 	if f.minElements == f.maxElements {
 		return f.minElements
 	}
-	return f.minElements + f.r.Intn(f.maxElements-f.minElements)
+	return f.minElements + f.r.Intn(f.maxElements-f.minElements+1)
 }
 
 func (f *Fuzzer) genShouldFill() bool {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -406,3 +406,23 @@ func TestFuzz_noCustom(t *testing.T) {
 		t.Errorf("expected Inner custom function to have been called")
 	}
 }
+
+func TestFuzz_NumElements(t *testing.T) {
+	f := New().NilChance(0).NumElements(0, 1)
+	obj := &struct {
+		A []int
+	}{}
+
+	tryFuzz(t, f, obj, func() (int, bool) {
+		if obj.A == nil {
+			return 1, false
+		}
+		return 2, len(obj.A) == 0
+	})
+	tryFuzz(t, f, obj, func() (int, bool) {
+		if obj.A == nil {
+			return 3, false
+		}
+		return 4, len(obj.A) == 1
+	})
+}


### PR DESCRIPTION
If `f.minElements` and `f.maxElements` aren't equal then `genElementCount` will never actually return `f.maxElements` because of an off-by-one in its use of `rand.Intn`.
