### PR TITLE
Fix charRange to allow picking the last item

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -471,15 +471,19 @@ func randBool(r *rand.Rand) bool {
 	return false
 }
 
+type int63nPicker interface {
+	Int63n(int64) int64
+}
+
 type charRange struct {
 	first, last rune
 }
 
 // choose returns a random unicode character from the given range, using the
 // given randomness source.
-func (r *charRange) choose(rand *rand.Rand) rune {
-	count := int64(r.last - r.first)
-	return r.first + rune(rand.Int63n(count))
+func (cr charRange) choose(r int63nPicker) rune {
+	count := int64(cr.last - cr.first)
+	return cr.first + rune(r.Int63n(count))
 }
 
 var unicodeRanges = []charRange{

--- a/fuzz.go
+++ b/fuzz.go
@@ -482,7 +482,7 @@ type charRange struct {
 // choose returns a random unicode character from the given range, using the
 // given randomness source.
 func (cr charRange) choose(r int63nPicker) rune {
-	count := int64(cr.last - cr.first)
+	count := int64(cr.last - cr.first + 1)
 	return cr.first + rune(r.Int63n(count))
 }
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fuzz
 
 import (
+	"math/rand"
 	"reflect"
 	"regexp"
 	"testing"
@@ -502,5 +503,45 @@ func TestFuzz_SkipPattern(t *testing.T) {
 			return 4, false
 		}
 		return 5, true
+	})
+}
+
+type int63mode int
+
+const (
+	modeRandom int63mode = iota
+	modeFirst
+	modeLast
+)
+
+type customInt63 struct {
+	mode int63mode
+}
+
+func (c customInt63) Int63n(n int64) int64 {
+	switch c.mode {
+	case modeFirst: return 0
+	case modeLast: return n-1
+	default: return rand.Int63n(n)
+	}
+}
+
+func Test_charRange_choose(t *testing.T) {
+	lowercaseLetters := charRange{'a', 'z'}
+
+	t.Run("Picks first", func(t *testing.T) {
+		r := customInt63{mode: modeFirst}
+		letter := lowercaseLetters.choose(r)
+		if letter != 'a' {
+			t.Errorf("Expected a, got %v", letter)
+		}
+	})
+
+	t.Run("Picks last", func(t *testing.T) {
+		r := customInt63{mode: modeLast}
+		letter := lowercaseLetters.choose(r)
+		if letter != 'y' {
+			t.Errorf("Expected y, got %v", letter)
+		}
 	})
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -540,8 +540,8 @@ func Test_charRange_choose(t *testing.T) {
 	t.Run("Picks last", func(t *testing.T) {
 		r := customInt63{mode: modeLast}
 		letter := lowercaseLetters.choose(r)
-		if letter != 'y' {
-			t.Errorf("Expected y, got %v", letter)
+		if letter != 'z' {
+			t.Errorf("Expected z, got %v", letter)
 		}
 	})
 }


### PR DESCRIPTION
Before this change, choose would never pick the last character of the set. This is not the expected behavior: if the range is a-z, we expect a,b,...,y,z to be picked in a uniform way.

