### PR TITLE
Implement fuzzing of complex types

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -450,10 +450,10 @@ var fillFuncMap = map[reflect.Kind]func(reflect.Value, *rand.Rand){
 		v.SetFloat(r.Float64())
 	},
 	reflect.Complex64: func(v reflect.Value, r *rand.Rand) {
-		panic("unimplemented")
+		v.SetComplex(complex128(complex(r.Float32(), r.Float32())))
 	},
 	reflect.Complex128: func(v reflect.Value, r *rand.Rand) {
-		panic("unimplemented")
+		v.SetComplex(complex(r.Float64(), r.Float64()))
 	},
 	reflect.String: func(v reflect.Value, r *rand.Rand) {
 		v.SetString(randString(r))

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -39,6 +39,8 @@ func TestFuzz_basic(t *testing.T) {
 		S    string
 		B    bool
 		T    time.Time
+		C64  complex64
+		C128 complex128
 	}{}
 
 	failed := map[string]int{}
@@ -85,6 +87,12 @@ func TestFuzz_basic(t *testing.T) {
 			failed[n] = failed[n] + 1
 		}
 		if n, v := "t", obj.T; v.IsZero() {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "c64", obj.C64; v == 0 {
+			failed[n] = failed[n] + 1
+		}
+		if n, v := "c128", obj.C128; v == 0 {
 			failed[n] = failed[n] + 1
 		}
 	}


### PR DESCRIPTION
From builtin.go:
The complex built-in function constructs a complex value from two floating-point
values. The real and imaginary parts must be of the same size, either float32 or
float64 (or assignable to them), and the return value will be the corresponding
complex type (complex64 for float32, complex128 for float64).