### PR TITLE
Skip fields if falled through for chan, interface, etc.

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -332,6 +332,11 @@ func (fc *fuzzerContext) doFuzz(v reflect.Value, flags uint64) {
 	case reflect.Interface:
 		fallthrough
 	default:
+		for _, pattern := range fc.fuzzer.skipFieldPatterns {
+			if pattern.MatchString(v.Type().Name()) {
+				return
+			}
+		}
 		panic(fmt.Sprintf("Can't handle %#v", v.Interface()))
 	}
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -482,7 +482,7 @@ func TestFuzz_Maxdepth(t *testing.T) {
 }
 
 func TestFuzz_SkipPattern(t *testing.T) {
-	obj := &struct {
+	obj := struct {
 		S1    string
 		S2    string
 		XXX_S string
@@ -492,12 +492,11 @@ func TestFuzz_SkipPattern(t *testing.T) {
 			XXX_S1 string
 			S2_XXX string
 		}
+		XXX_ERR error
 	}{}
 
 	f := New().NilChance(0).SkipFieldsWithPattern(regexp.MustCompile(`^XXX_`))
-	f.Fuzz(obj)
-
-	tryFuzz(t, f, obj, func() (int, bool) {
+	tryFuzz(t, f, &obj, func() (int, bool) {
 		if obj.XXX_S != "" {
 			return 1, false
 		}


### PR DESCRIPTION
Before if a field is an interface, the fuzzer will panic directly.
Now check if that field is skipped before doing panic