### PR TITLE
Update import statement to reference correct library name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ example a fuzz test for a the function `mypackage.MyFunc` that takes an int argu
 // +build gofuzz
 package mypackage
 
-import "github.com/google/go-fuzz"
+import fuzz "github.com/google/gofuzz"
 
 func Fuzz(data []byte) int {
         var i int

--- a/fuzz.go
+++ b/fuzz.go
@@ -80,7 +80,7 @@ func NewWithSeed(seed int64) *Fuzzer {
 //
 // // +build gofuzz
 // package mypacakge
-// import "github.com/google/go-fuzz"
+// import fuzz "github.com/google/gofuzz"
 // func Fuzz(data []byte) int {
 // 	var i int
 // 	fuzz.NewFromGoFuzz(data).Fuzz(&i)


### PR DESCRIPTION
The example in the documentation references the go-fuzz library rather than gofuzz, which appears to be a mistake.  This just tweaks that so that the example should hopefully work when copied.