### PR TITLE
Optimize randBool() and randString()

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -526,7 +526,7 @@ func randString(r *rand.Rand) string {
 	n := r.Intn(20)
 	sb := strings.Builder{}
 	sb.Grow(n)
-	for i := 0 ;i<n; i++ {
+	for i := 0; i < n; i++ {
 		sb.WriteRune(unicodeRanges[r.Intn(len(unicodeRanges))].choose(r))
 	}
 	return sb.String()

--- a/fuzz.go
+++ b/fuzz.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/gofuzz/bytesource"
+	"strings"
 )
 
 // fuzzFuncMap is a map from a type to a fuzzFunc that handles that type.
@@ -523,11 +524,12 @@ var unicodeRanges = []charRange{
 // may include a variety of (valid) UTF-8 encodings.
 func randString(r *rand.Rand) string {
 	n := r.Intn(20)
-	runes := make([]rune, n)
-	for i := range runes {
-		runes[i] = unicodeRanges[r.Intn(len(unicodeRanges))].choose(r)
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for i := 0 ;i<n; i++ {
+		sb.WriteRune(unicodeRanges[r.Intn(len(unicodeRanges))].choose(r))
 	}
-	return string(runes)
+	return sb.String()
 }
 
 // randUint64 makes random 64 bit numbers.

--- a/fuzz.go
+++ b/fuzz.go
@@ -495,10 +495,7 @@ var fillFuncMap = map[reflect.Kind]func(reflect.Value, *rand.Rand){
 
 // randBool returns true or false randomly.
 func randBool(r *rand.Rand) bool {
-	if r.Int()&1 == 1 {
-		return true
-	}
-	return false
+	return r.Int31()&(1<<30) == 0
 }
 
 type int63nPicker interface {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -528,9 +528,12 @@ type customInt63 struct {
 
 func (c customInt63) Int63n(n int64) int64 {
 	switch c.mode {
-	case modeFirst: return 0
-	case modeLast: return n-1
-	default: return rand.Int63n(n)
+	case modeFirst:
+		return 0
+	case modeLast:
+		return n - 1
+	default:
+		return rand.Int63n(n)
 	}
 }
 
@@ -571,14 +574,14 @@ func BenchmarkRandBool(b *testing.B) {
 	rs := rand.New(rand.NewSource(123))
 
 	for i := 0; i < b.N; i++ {
-			randBool(rs)
-    }
+		randBool(rs)
+	}
 }
 
 func BenchmarkRandString(b *testing.B) {
 	rs := rand.New(rand.NewSource(123))
 
 	for i := 0; i < b.N; i++ {
-			randString(rs)
-    }
+		randString(rs)
+	}
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -566,3 +566,19 @@ func TestNewFromGoFuzz(t *testing.T) {
 		t.Errorf("Fuzz(%q) = %d, want: %d", input, got, want)
 	}
 }
+
+func BenchmarkRandBool(b *testing.B) {
+	rs := rand.New(rand.NewSource(123))
+
+	for i := 0; i < b.N; i++ {
+			randBool(rs)
+    }
+}
+
+func BenchmarkRandString(b *testing.B) {
+	rs := rand.New(rand.NewSource(123))
+
+	for i := 0; i < b.N; i++ {
+			randString(rs)
+    }
+}


### PR DESCRIPTION
I love this library, small but gets the job done! :)

I have tinkered a bit with the functions to generate bools and strings and made them a bit faster. Hopefully it will save someone some clocks when running tests.

The code speeds up bool generation 3-fold. I've ran some benchmarks on GCP VM's and my local MacBook:

> My MacBook Pro:
> 
> BenchmarkRandBool-8             75312272                14.5 ns/op
> BenchmarkRandBoolNew-8        235223112                5.06 ns/op
> BenchmarkRandStringStock-8       1439635               841 ns/op
> BenchmarkRandStringBuilder-8     1541736               775 ns/op
> 
> 8 core GCP E2:
> 
> BenchmarkRandBool-8             70003590                16.6 ns/op
> BenchmarkRandBoolNew-8        236062108                5.08 ns/op
> BenchmarkRandStringStock-8       1370116               874 ns/op
> BenchmarkRandStringBuilder-8     1484086               807 ns/op
> 
> 8 core GCP N2 (Intel Cascade Lake):
> 
> BenchmarkRandBool-8             91276062                13.1 ns/op
> BenchmarkRandBoolNew-8        301435986                3.98 ns/op
> BenchmarkRandStringStock-8       1743852               688 ns/op
> BenchmarkRandStringBuilder-8     1883102               638 ns/op
> 
> 8 core GCP N1 (Intel Skylake):
> 
> BenchmarkRandBool-8             71896552                16.5 ns/op
> BenchmarkRandBoolNew-8        239149131                5.03 ns/op
> BenchmarkRandStringStock-8       1375860               873 ns/op
> BenchmarkRandStringBuilder-8     1484378               808 ns/op

randString() will be 5-7% due to less data being moved around (thanks to strings.Builder)

randString() memory usage change:

> BenchmarkRandStringStock-8       1543179               772 ns/op              71 B/op          1 allocs/op
> BenchmarkRandStringBuilder-8     1639436               735 ns/op              48 B/op          1 allocs/op