### PR TITLE
Fix bug where NilChance(0) could still result in nil

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -172,7 +172,7 @@ func (f *Fuzzer) genElementCount() int {
 }
 
 func (f *Fuzzer) genShouldFill() bool {
-	return f.r.Float64() > f.nilChance
+	return f.r.Float64() >= f.nilChance
 }
 
 // MaxDepth sets the maximum number of recursive fuzz calls that will be made

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -515,6 +515,35 @@ func TestFuzz_SkipPattern(t *testing.T) {
 	})
 }
 
+func TestFuzz_NilChanceZero(t *testing.T) {
+	// This data source for random will result in the following four values
+	// being sampled (the first, 0, being the most interesting case):
+	//   0; 0.8727288671879787; 0.5547307616625858; 0.021885026049502695
+	data := []byte("H0000000\x00")
+	f := NewFromGoFuzz(data).NilChance(0)
+
+	var fancyStruct struct {
+		A, B, C, D *string
+	}
+	f.Fuzz(&fancyStruct) // None of the pointers should be nil, as NilChance is 0
+
+	if fancyStruct.A == nil {
+		t.Error("First value in struct was nil")
+	}
+
+	if fancyStruct.B == nil {
+		t.Error("Second value in struct was nil")
+	}
+
+	if fancyStruct.C == nil {
+		t.Error("Third value in struct was nil")
+	}
+
+	if fancyStruct.D == nil {
+		t.Error("Fourth value in struct was nil")
+	}
+}
+
 type int63mode int
 
 const (


### PR DESCRIPTION
Closes #46.

As discussed there, using `NilChance(0)` to prevent gofuzz from giving `nil`s contained a very minor bug where it might still give `nil` because a randomly sampled `0` is not greater than the configured `0`. This has been fixed by using `>=` instead of `>` when comparing the configured `nilChance` against randomly sampled values.

I also added a test case where a seeded RNG is used which will give `0` as it's first value in order to verify the bug is not reintroduced. Let me know if I should change anything about the test (or feel free to commit those changes yourself :slightly_smiling_face:).