### PR TITLE
Include Type in panic message

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -334,7 +334,7 @@ func (fc *fuzzerContext) doFuzz(v reflect.Value, flags uint64) {
 	case reflect.Interface:
 		fallthrough
 	default:
-		panic(fmt.Sprintf("Can't handle %#v", v.Interface()))
+		panic(fmt.Sprintf("Can't handle type %v with value %#v", v.Type(), v.Interface()))
 	}
 }
 


### PR DESCRIPTION
The switch is looking at type, not the value. It should be easier to understand these failures when the message includes the type. I ran into this problem while using `gofuzz`.

Previous the message was:

    Can't handle <nil>

After this change:

    Can't handle type interface {} with value <nil>