### PR TITLE
Allow Continue.Fuzz to accept a reflect.Value

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -403,9 +403,13 @@ type Continue struct {
 	*rand.Rand
 }
 
-// Fuzz continues fuzzing obj. obj must be a pointer.
+// Fuzz continues fuzzing obj. obj must be a pointer or a reflect.Value of a
+// pointer.
 func (c Continue) Fuzz(obj interface{}) {
-	v := reflect.ValueOf(obj)
+	v, ok := obj.(reflect.Value)
+	if !ok {
+		v = reflect.ValueOf(obj)
+	}
 	if v.Kind() != reflect.Ptr {
 		panic("needed ptr!")
 	}
@@ -418,7 +422,10 @@ func (c Continue) Fuzz(obj interface{}) {
 // conformance.  This applies only to obj and not other instances of obj's
 // type.
 func (c Continue) FuzzNoCustom(obj interface{}) {
-	v := reflect.ValueOf(obj)
+	v, ok := obj.(reflect.Value)
+	if !ok {
+		v = reflect.ValueOf(obj)
+	}
 	if v.Kind() != reflect.Ptr {
 		panic("needed ptr!")
 	}


### PR DESCRIPTION
This is a small optimization, so I completely understand if you would rather keep
the existing interface and close this PR without merging. I made the change before
I realized I could use `reflect.Value.Addr()` as the argument. I thought I would open this
PR anyway, in case there is interest in the small optimization. I imagine in some larger
test suites it might save a little time by avoiding the need to reflect again.

`Continue.Fuzz` (and `FuzzNoCustom`) immediately convert the `interface{}`
into a `reflect.Value`. In some cases the caller may already have a
`reflect.Value`, so accepting that type makes it easier to write custom
fuzz functions.

One use case for this is ignoring a field on a struct. The `SkipFieldsWithPattern`
option is a good choice when the field name should always be ignored. In other
cases a field name may exist on multiple structs, and using a regex pattern
would result in the field being skipped in all cases. To ignore a field by name
on only a single struct a custom fuzz function can use reflect to iterate over
the fields, and call `c.Fuzz()` on all fields except for the ignored field.