### PR TITLE
Reduce the chance a test can flake

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -135,7 +135,7 @@ func TestFuzz_structptr(t *testing.T) {
 	checkFailed(t, failed)
 }
 
-// tryFuzz tries fuzzing up to 20 times. Fail if check() never passes, report the highest
+// tryFuzz tries fuzzing up to 30 times. Fail if check() never passes, report the highest
 // stage it ever got to.
 func tryFuzz(t *testing.T, f *Fuzzer, obj interface{}, check func() (stage int, passed bool)) {
 	t.Helper()

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -46,7 +46,7 @@ func TestFuzz_basic(t *testing.T) {
 	}{}
 
 	failed := map[string]int{}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		New().Fuzz(obj)
 
 		if n, v := "i", obj.I; v == 0 {
@@ -102,8 +102,9 @@ func TestFuzz_basic(t *testing.T) {
 }
 
 func checkFailed(t *testing.T, failed map[string]int) {
+	t.Helper()
 	for k, v := range failed {
-		if v > 8 {
+		if v > 18 {
 			t.Errorf("%v seems to not be getting set, was zero value %v times", k, v)
 		}
 	}
@@ -118,7 +119,7 @@ func TestFuzz_structptr(t *testing.T) {
 
 	f := New().NilChance(.5)
 	failed := map[string]int{}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		f.Fuzz(obj)
 
 		if n, v := "a not nil", obj.A; v == nil {
@@ -137,8 +138,9 @@ func TestFuzz_structptr(t *testing.T) {
 // tryFuzz tries fuzzing up to 20 times. Fail if check() never passes, report the highest
 // stage it ever got to.
 func tryFuzz(t *testing.T, f *Fuzzer, obj interface{}, check func() (stage int, passed bool)) {
+	t.Helper()
 	maxStage := 0
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 30; i++ {
 		f.Fuzz(obj)
 		stage, passed := check()
 		if stage > maxStage {


### PR DESCRIPTION
This commit adjust the values used in tests to reduce the probability of a flake.

For `tryFuzz`, increase the attempts from 20 to 30.
For `checkFailed`, increase the attempts to 20, and only fail if 19/20 iteration received a zero value. Previously it would fail if 9/10 received zero values.
Also adds t.Helper() to the two test helpers.

I was testing this with `go test -count=100` and I saw much fewer flakes.