### PR TITLE
Added Support for Linux on Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+arch:
+  - amd64
+  - ppc64le
 
 go:
   - 1.13.x


### PR DESCRIPTION

Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/gofuzz/builds/191587932
Please have a look.

Regards,
ujjwal