### PR TITLE
Make the fuzzer threadsafe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ go:
   - master
 
 script:
-  - go test -cover
+  - go test -race -cover

--- a/fuzz.go
+++ b/fuzz.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"reflect"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/google/gofuzz/bytesource"
@@ -40,6 +41,8 @@ type Fuzzer struct {
 	maxElements       int
 	maxDepth          int
 	skipFieldPatterns []*regexp.Regexp
+
+	fuzzLock sync.Mutex
 }
 
 // New returns a new Fuzzer. Customize your Fuzzer further by calling Funcs,
@@ -205,6 +208,9 @@ func (f *Fuzzer) SkipFieldsWithPattern(pattern *regexp.Regexp) *Fuzzer {
 // golang :/ ) Intended for tests, so will panic on bad input or unimplemented
 // fields.
 func (f *Fuzzer) Fuzz(obj interface{}) {
+	f.fuzzLock.Lock()
+	defer f.fuzzLock.Unlock()
+
 	v := reflect.ValueOf(obj)
 	if v.Kind() != reflect.Ptr {
 		panic("needed ptr!")
@@ -221,6 +227,9 @@ func (f *Fuzzer) Fuzz(obj interface{}) {
 // obj must be a pointer. Only exported (public) fields can be set (thanks, golang :/ )
 // Intended for tests, so will panic on bad input or unimplemented fields.
 func (f *Fuzzer) FuzzNoCustom(obj interface{}) {
+	f.fuzzLock.Lock()
+	defer f.fuzzLock.Unlock()
+
 	v := reflect.ValueOf(obj)
 	if v.Kind() != reflect.Ptr {
 		panic("needed ptr!")

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -625,6 +626,18 @@ func Test_UnicodeRanges_CustomStringFuzzFunc(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestFuzzThreadSafety lets the racedetector find races
+func TestFuzzThreadSafety(t *testing.T) {
+	f := New()
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() { f.Fuzz(&[]string{}); wg.Done() }()
+	go func() { f.Fuzz(&[]string{}); wg.Done() }()
+	wg.Wait()
 }
 
 func TestNewFromGoFuzz(t *testing.T) {


### PR DESCRIPTION
The fuzzer uses a prng from math/rand.NewSource which is not threadsafe.
This change adds a simple lock into the fuzzer to allow using it from
multiple goroutines in parallel.

/assign @lavalamp 