### PR TITLE
Fix time.Time fuzzing to generate only valid zone offsets

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -25,8 +25,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/gofuzz/bytesource"
 	"strings"
+
+	"github.com/google/gofuzz/bytesource"
 )
 
 // fuzzFuncMap is a map from a type to a fuzzFunc that handles that type.
@@ -88,12 +89,13 @@ func NewWithSeed(seed int64) *Fuzzer {
 // // +build gofuzz
 // package mypacakge
 // import fuzz "github.com/google/gofuzz"
-// func Fuzz(data []byte) int {
-// 	var i int
-// 	fuzz.NewFromGoFuzz(data).Fuzz(&i)
-// 	MyFunc(i)
-// 	return 0
-// }
+//
+//	func Fuzz(data []byte) int {
+//		var i int
+//		fuzz.NewFromGoFuzz(data).Fuzz(&i)
+//		MyFunc(i)
+//		return 0
+//	}
 func NewFromGoFuzz(data []byte) *Fuzzer {
 	return New().RandSource(bytesource.New(data))
 }
@@ -485,7 +487,9 @@ func fuzzTime(t *time.Time, c Continue) {
 	// Allow for about 1000 years of random time values, which keeps things
 	// like JSON parsing reasonably happy.
 	sec = c.Rand.Int63n(1000 * 365 * 24 * 60 * 60)
-	c.Fuzz(&nsec)
+	// Nanosecond values greater than 1Bn are technically allowed but result in
+	// time.Time values with invalid timezone offsets.
+	nsec = c.Rand.Int63n(999999999)
 	*t = time.Unix(sec, nsec)
 }
 


### PR DESCRIPTION
As described in #14 comment: this patch fixes the default fuzzer for `time.Time` to limit it's output to time values that will serialise correctly.

My understanding of the issue is that while the [`time.Unix` docs](https://pkg.go.dev/time#Unix) specify that:

> It is valid to pass nsec outside the range [0, 999999999]

Doing so seems to break `time.MarshalBinary` which will return an error about the timezone offset being invalid.

Arguably that could be considered a bug in `time.Time` but I think it's reasonable to just accommodate and only generate nanoseconds in the sub-second range.