### PR TITLE
Add AllowUnsupportedFields to ignore interface/etc fields and not panic

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -531,21 +531,21 @@ func TestFuzzer_AllowUnsupportedFields(t *testing.T) {
 
 	failingFuzz(&obj)
 	if obj.InterfaceField != nil {
-		t.Errorf("Expected obj.stringField to be empty")
+		t.Errorf("Expected obj.InterfaceField to be empty")
 	}
 
 	f.AllowUnsupportedFields(true)
 	obj = S{}
 	f.Fuzz(&obj)
 	if obj.InterfaceField != nil {
-		t.Errorf("Expected obj.stringField to be empty")
+		t.Errorf("Expected obj.InterfaceField to be empty")
 	}
 
 	f.AllowUnsupportedFields(false)
 	obj = S{}
 	failingFuzz(&obj)
 	if obj.InterfaceField != nil {
-		t.Errorf("Expected obj.stringField to be empty")
+		t.Errorf("Expected obj.InterfaceField to be empty")
 	}
 }
 


### PR DESCRIPTION
## Description

This adds a new property to the fuzzer: `AllowUnsupportedFields`.
If used, when the fuzzer sees an unsupported field (like an interface, func or a channel) it will ignore it instead of panic.
This resolves #27 